### PR TITLE
Additional protocol info for precision neo

### DIFF
--- a/abbott/freestyle-precision-neo.md
+++ b/abbott/freestyle-precision-neo.md
@@ -1,4 +1,4 @@
-# FreeStyle Precision Neo
+# FreeStyle Precision Neo / FreeStyle Optium Neo
 
 Reverse engineered by [Diego Elio Pettenò](mailto:flameeyes@flameeyes.eu).
 
@@ -7,6 +7,8 @@ Reverse engineered by [Diego Elio Pettenò](mailto:flameeyes@flameeyes.eu).
 The FreeStyle Precision Neo is a glucometer that can also read special β-ketones
 testing strips. Unfortunately those strips are not available in Europe, so the
 reverse engineering in this document is
+
+The FreeStyle Precision Neo has the same protocol as the FreeStyle Optium Neo which is probably the same device in other countries outside the US.
 
 ## Protocol
 
@@ -26,7 +28,7 @@ it follows the *Multiple records command* output format as described in the
 shared protocol documentation.
 
 The first field in the record specify the type of record; type 7 is a blood
-glucose reading, other events have not been identified yet.
+glucose reading, type 10 is an insulin input that was made on the device.
 
 #### Blood glucose record fields
 
@@ -49,3 +51,26 @@ glucose reading, other events have not been identified yet.
   17. `unknown`
   18. `unknown`
   19. `unknown`
+
+#### Insulin record fields
+
+  1. `type = "10"`
+  2. `id`
+  3. `month = 1*2DIGIT`
+  4. `day = 1*2DIGIT`
+  5. `year = 1*2DIGIT`
+  6. `hour = 1*2DIGIT`
+  7. `minute = 1*2DIGIT`
+  8. `unknown`
+  9. `insulinType = "0"|"1"|"2"|"3"`
+  10. `value = 1*DIGIT`
+  11. `unknown`
+  12. `unknown`
+  13. `unknown`
+  
+  insulinType refers to the type of insulin and the time of day as follow:
+  0 = morning long-acting insulin
+  1 = breakfast short-acting insulin
+  2 = lunch short-acting insulin
+  3 = evening long-acting insulin
+  4 = dinner short-acting insulin

--- a/abbott/freestyle-precision-neo.md
+++ b/abbott/freestyle-precision-neo.md
@@ -69,8 +69,13 @@ glucose reading, type 10 is an insulin input that was made on the device.
   13. `unknown`
   
   insulinType refers to the type of insulin and the time of day as follow:
+  
   0 = morning long-acting insulin
+  
   1 = breakfast short-acting insulin
+  
   2 = lunch short-acting insulin
+  
   3 = evening long-acting insulin
+  
   4 = dinner short-acting insulin


### PR DESCRIPTION
I have added additional info for the precision neo. When insulin is added on the device the record with type 10 is sent.
On another note: Precision Neo is identical to Optium Neo in other countries. I have also added this comment.