### PR TITLE
Ketone Reading factor corrected

### DIFF
--- a/abbott/freestyle-libre.md
+++ b/abbott/freestyle-libre.md
@@ -116,7 +116,9 @@ change event.
       represent the blood sugar reading in mg/dL.
 
       When `reading-type` is `blood-ketone`, this represent the β-ketone
-      reading in mmol/l after apply ceil(`value`/2)/10.
+      reading in mmol/l after apply `value`/18. It seems that the value is reported 
+      in mg/dL and the conversion is using the wrong molar mass system for conversion.
+      But based on actual measurements the results are correct this way.
   14. `unknown = "0" / "1"`
 
       This appears to be 0 for values read from a blood strip, and 1 for values


### PR DESCRIPTION
Hi,

long time not talked.

I have been in contact with a user who informed me that the Ketone readouts were wrong. Analysing the problem I found out that the factor is not ceil(value/2)/10 but value/18. Funny enough this is the conversion factor to convert glucose values from mg/dL to mmol/L. I do not think that the molecular mass for ketone is the same as for blood glucose, but it seems that the engineers just used this factor (apart from the fact that ketone is reported in mmol/L everywhere in the world). At least the tests with my user and the comparison to the results of the libre app have shown that with this conversion the values are correct.

I have corrected the description for this, so that others can also correct this.

Hope you are doing fine anyway :-)